### PR TITLE
fix organize imports

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,7 +64,7 @@ function getAllCodeActionsForFile(file: vscode.Uri, kind: vscode.CodeActionKind)
         vscode.commands.executeCommand('vscode.executeCodeActionProvider',
             file,
             fakeWholeDocumentRange,
-            kind));
+            kind.value));
 }
 
 function actionFilter(targetKind: vscode.CodeActionKind) {


### PR DESCRIPTION
There was a regression in this package where `Organize Imports in Folder` started quietly failing. This resolves that.

Fixes #3
Fixes #4